### PR TITLE
Add feature to find card reader object via name str

### DIFF
--- a/blocksec2go/commands.py
+++ b/blocksec2go/commands.py
@@ -15,11 +15,11 @@ def find_reader(reader_name):
     Returns:
         reader:
             :obj:`PyScardReader`: PyScard wrapper object.
-            Chooses first reader with that name if multiple 
+            Chooses first reader with specified name if multiple 
             readers are found.
 
     Raises:
-        ReaderError: No reader found with that name.
+        ReaderError: No reader found with specified name.
         
         Any exceptions thrown by the reader wrapper are passed through.
     """

--- a/blocksec2go/commands.py
+++ b/blocksec2go/commands.py
@@ -19,7 +19,7 @@ def find_reader(reader_name):
             readers are found.
 
     Raises:
-        ReaderError: No reader found with specified name.
+        RuntimeError: No reader found with specified name.
         
         Any exceptions thrown by the reader wrapper are passed through.
     """
@@ -30,8 +30,8 @@ def find_reader(reader_name):
             try:
                 return open_pyscard(r[r.index(reader)])
             except:
-                raise Exception('No card on reader')
-    raise Exception('No reader found')
+                raise RuntimeError('No card on reader')
+    raise RuntimeError('No reader found')
 
 def select_app(reader):
     """ Sends command to select the Blockchain Security2GO application

--- a/blocksec2go/commands.py
+++ b/blocksec2go/commands.py
@@ -1,6 +1,38 @@
 import logging
 logger = logging.getLogger(__name__)
 
+from smartcard.System import readers
+from blocksec2go.comm.pyscard import open_pyscard
+
+def find_reader(reader_name):
+    """ Looks for a specific card reader
+
+    Tries to find a card reader with specified name.
+
+    Args:
+        reader_name (str): string providing name of reader
+
+    Returns:
+        reader:
+            :obj:`PyScardReader`: A card reader with the name 
+            "reader_name". Chooses first reader with that name 
+            if multiple found.
+
+    Raises:
+        ReaderError: No reader found with that name.
+        
+        Any exceptions thrown by the reader wrapper are passed through.
+    """
+    logger.debug('FIND READER name %s', reader_name)
+    r = readers()
+    for reader in r:
+        if reader_name in str(reader):
+            try:
+                return open_pyscard(r[r.index(reader)])
+            except:
+                raise Exception('No card on reader')
+    raise Exception('No reader found')
+
 def select_app(reader):
     """ Sends command to select the Blockchain Security2GO application
 

--- a/blocksec2go/commands.py
+++ b/blocksec2go/commands.py
@@ -14,9 +14,9 @@ def find_reader(reader_name):
 
     Returns:
         reader:
-            :obj:`PyScardReader`: A card reader with the name 
-            "reader_name". Chooses first reader with that name 
-            if multiple found.
+            :obj:`PyScardReader`: PyScard wrapper object.
+            Chooses first reader with that name if multiple 
+            readers are found.
 
     Raises:
         ReaderError: No reader found with that name.


### PR DESCRIPTION
`find_reader("name of card reader")`
This new command allows the user to find a smartcard reader object, which is used for consequent commands, based on its name. The entered name must resemble the name which gets outputted via the cli command `blocksec2go list_readers` but does not have to fully match it. So as an example instead of writing `"company-name reader-name exact-modell-number etc..."` you can simply write `"company-name reader-name"` and it should automatically find a reader with that name without writing out the full name. This is especially important for cross platform usage since on different devices the full name often doesn't match. 

If there are multiple card readers with the same name the first one recognized by the program gets used!