### PR TITLE
Add an example to show get_card_info usage

### DIFF
--- a/blocksec2go/commands.py
+++ b/blocksec2go/commands.py
@@ -15,11 +15,11 @@ def find_reader(reader_name):
     Returns:
         reader:
             :obj:`PyScardReader`: PyScard wrapper object.
-            Chooses first reader with that name if multiple 
+            Chooses first reader with specified name if multiple 
             readers are found.
 
     Raises:
-        ReaderError: No reader found with that name.
+        ReaderError: No reader found with specified name.
         
         Any exceptions thrown by the reader wrapper are passed through.
     """

--- a/blocksec2go/commands.py
+++ b/blocksec2go/commands.py
@@ -19,7 +19,7 @@ def find_reader(reader_name):
             readers are found.
 
     Raises:
-        ReaderError: No reader found with specified name.
+        RuntimeError: No reader found with specified name.
         
         Any exceptions thrown by the reader wrapper are passed through.
     """
@@ -30,8 +30,8 @@ def find_reader(reader_name):
             try:
                 return open_pyscard(r[r.index(reader)])
             except:
-                raise Exception('No card on reader')
-    raise Exception('No reader found')
+                raise RuntimeError('No card on reader')
+    raise RuntimeError('No reader found')
 
 def select_app(reader):
     """ Sends command to select the Blockchain Security2GO application

--- a/blocksec2go/commands.py
+++ b/blocksec2go/commands.py
@@ -1,6 +1,38 @@
 import logging
 logger = logging.getLogger(__name__)
 
+from smartcard.System import readers
+from blocksec2go.comm.pyscard import open_pyscard
+
+def find_reader(reader_name):
+    """ Looks for a specific card reader
+
+    Tries to find a card reader with specified name.
+
+    Args:
+        reader_name (str): string providing name of reader
+
+    Returns:
+        reader:
+            :obj:`PyScardReader`: A card reader with the name 
+            "reader_name". Chooses first reader with that name 
+            if multiple found.
+
+    Raises:
+        ReaderError: No reader found with that name.
+        
+        Any exceptions thrown by the reader wrapper are passed through.
+    """
+    logger.debug('FIND READER name %s', reader_name)
+    r = readers()
+    for reader in r:
+        if reader_name in str(reader):
+            try:
+                return open_pyscard(r[r.index(reader)])
+            except:
+                raise Exception('No card on reader')
+    raise Exception('No reader found')
+
 def select_app(reader):
     """ Sends command to select the Blockchain Security2GO application
 

--- a/blocksec2go/commands.py
+++ b/blocksec2go/commands.py
@@ -14,9 +14,9 @@ def find_reader(reader_name):
 
     Returns:
         reader:
-            :obj:`PyScardReader`: A card reader with the name 
-            "reader_name". Chooses first reader with that name 
-            if multiple found.
+            :obj:`PyScardReader`: PyScard wrapper object.
+            Chooses first reader with that name if multiple 
+            readers are found.
 
     Raises:
         ReaderError: No reader found with that name.

--- a/examples/basic-card-info/README.md
+++ b/examples/basic-card-info/README.md
@@ -12,6 +12,8 @@ If you are unsure what the name of your card reader is, use the command `blockse
 
 For this example the card reader uTrust 3700 F by the company Identiv was used:
 
+    reader_name = 'Identiv uTrust 3700 F'
+    ...
     reader = blocksec2go.find_reader(reader_name)
 
 This function returns us the reader as an object to be used with other commands from the blocksec2go library.
@@ -20,6 +22,15 @@ The command `select_app(reader)` has to be used in every application that tries 
 
     pin_active, card_id, version = blocksec2go.select_app(reader)
 
-`pin_active` is a bool that tells us if the card is locked with a PIN code.  
-The variable `card_id` is a unique card identifier which corresponds to that specific smartcard.  
-The string `version` shows the BlockSec2Go card firmware version.
+The bool `pin_active` that tells us if the card is locked with a PIN code.  
+The variable `card_id` is a unique card identifier which corresponds to that specific BlockSec2Go card.  
+The string `version` shows the card firmware version.
+
+Before you run the example script on your machine make sure to replace the string from `reader_name` with the name of your card reader. Also make sure that everything is connected and the BlockSec2Go card is placed properly on the reader.
+
+Your Output should look something like:
+
+    Found the specified reader and a card!
+    Is PIN enabled? True
+    Card ID (hex): 02090c2900020027000c
+    Version: v1.0

--- a/examples/basic-card-info/README.md
+++ b/examples/basic-card-info/README.md
@@ -1,0 +1,25 @@
+# Getting basic card information example
+
+This example shows you how with just a few lines of code you can get the basic card information of your BlockSecurity2Go card.
+
+First the main blocksec2go library will be imported, since it provides us with an easy way to talk with the card reader and more importantly with the card itself:
+
+    import blocksec2go
+
+Before we can actually communicate with the card we need to find a card reader with a smartcard connected to it. This can be done by using the command `find_reader('name of card reader')`.
+
+If you are unsure what the name of your card reader is, use the command `blocksec2go list_readers` in your cli. Keep in mind that the exact name of the reader can vary across platforms so try keeping the name you enter in the function as simple as possible so it can also be recognised on another platforms too.
+
+For this example the card reader uTrust 3700 F by the company Identiv was used:
+
+    reader = blocksec2go.find_reader(reader_name)
+
+This function returns us the reader as an object to be used with other commands from the blocksec2go library.
+
+The command `select_app(reader)` has to be used in every application that tries to communicate with the BlockSec2Go card because it activates all the Blockchain commands on the card. It also simultaneously returns us some basic information about the card in form of a tuple:
+
+    pin_active, card_id, version = blocksec2go.select_app(reader)
+
+`pin_active` is a bool that tells us if the card is locked with a PIN code.  
+The variable `card_id` is a unique card identifier which corresponds to that specific smartcard.  
+The string `version` shows the BlockSec2Go card firmware version.

--- a/examples/basic-card-info/get_card_info_example.py
+++ b/examples/basic-card-info/get_card_info_example.py
@@ -1,0 +1,25 @@
+import blocksec2go
+
+if('__main__' == __name__):
+  reader = None
+  reader_name = 'Identiv uTrust 3700 F'
+  while(reader == None):
+    try:
+      reader = blocksec2go.find_reader(reader_name)
+      print('Found the specified reader and a card!')
+    except Exception as details:
+      if('No reader found' == str(details)):
+        print('No card reader found!     ', end='\r')
+      elif('No card on reader' == str(details)):
+        print('Found reader, but no card!', end='\r')
+      else:
+        print('ERROR:', details)
+        raise SystemExit
+  try:
+    pin_active, card_id, version = blocksec2go.select_app(reader)
+  except Exception as details:
+    print('ERROR:', details)
+    raise SystemExit
+  print('Is PIN enabled?', pin_active)
+  print('Card ID (hex):', card_id.hex())
+  print('Version: ' + version)

--- a/examples/get-card-info/README.md
+++ b/examples/get-card-info/README.md
@@ -1,0 +1,36 @@
+# Getting basic card information example
+
+This example shows you how with just a few lines of code you can get the basic card information of your BlockSecurity2Go card.
+
+First the main blocksec2go library will be imported, since it provides us with an easy way to talk with the card reader and more importantly with the card itself:
+
+    import blocksec2go
+
+Before we can actually communicate with the card we need to find a card reader with a smartcard connected to it. This can be done by using the command `find_reader('name of card reader')`.
+
+If you are unsure what the name of your card reader is, use the command `blocksec2go list_readers` in your cli. Keep in mind that the exact name of the reader can vary across platforms so try keeping the name you enter in the function as simple as possible so it can also be recognised on another platforms too.
+
+For this example the card reader uTrust 3700 F by the company Identiv was used:
+
+    reader_name = 'Identiv uTrust 3700 F'
+    ...
+    reader = blocksec2go.find_reader(reader_name)
+
+This function returns us the reader as an object to be used with other commands from the blocksec2go library.
+
+The command `select_app(reader)` has to be used in every application that tries to communicate with the BlockSec2Go card because it activates all the Blockchain commands on the card. It also simultaneously returns us some basic information about the card in form of a tuple:
+
+    pin_active, card_id, version = blocksec2go.select_app(reader)
+
+The bool `pin_active` that tells us if the card is locked with a PIN code.  
+The variable `card_id` is a unique card identifier which corresponds to that specific BlockSec2Go card.  
+The string `version` shows the card firmware version.
+
+Before you run the example script on your machine make sure to replace the string from `reader_name` with the name of your card reader. Also make sure that everything is connected and the BlockSec2Go card is placed properly on the reader.
+
+Your Output should look something like:
+
+    Found the specified reader and a card!
+    Is PIN enabled? True
+    Card ID (hex): 02090c2900020027000c
+    Version: v1.0

--- a/examples/get-card-info/get_card_info_example.py
+++ b/examples/get-card-info/get_card_info_example.py
@@ -1,0 +1,25 @@
+import blocksec2go
+
+if('__main__' == __name__):
+  reader = None
+  reader_name = 'Identiv uTrust 3700 F'
+  while(reader == None):
+    try:
+      reader = blocksec2go.find_reader(reader_name)
+      print('Found the specified reader and a card!')
+    except Exception as details:
+      if('No reader found' == str(details)):
+        print('No card reader found!     ', end='\r')
+      elif('No card on reader' == str(details)):
+        print('Found reader, but no card!', end='\r')
+      else:
+        print('ERROR:', details)
+        raise SystemExit
+  try:
+    pin_active, card_id, version = blocksec2go.select_app(reader)
+  except Exception as details:
+    print('ERROR:', details)
+    raise SystemExit
+  print('Is PIN enabled?', pin_active)
+  print('Card ID (hex):', card_id.hex())
+  print('Version: ' + version)


### PR DESCRIPTION
This example includes a simple python script showing the usage of the functions `find_reader` and `select_app`. It also includes a documentation explaining how the program uses these functions to some basic card information and how a person might use this example themselves.