### PR TITLE
Add example to show usage of functions find_reader and select_app

### DIFF
--- a/examples/get-card-info/README.md
+++ b/examples/get-card-info/README.md
@@ -1,0 +1,36 @@
+# Getting basic card information example
+
+This example shows you how with just a few lines of code you can get the basic card information of your BlockSecurity2Go card.
+
+First the main blocksec2go library will be imported, since it provides us with an easy way to talk with the card reader and more importantly with the card itself:
+
+    import blocksec2go
+
+Before we can actually communicate with the card we need to find a card reader with a smartcard connected to it. This can be done by using the command `find_reader('name of card reader')`.
+
+If you are unsure what the name of your card reader is, use the command `blocksec2go list_readers` in your cli. Keep in mind that the exact name of the reader can vary across platforms so try keeping the name you enter in the function as simple as possible so it can also be recognised on another platforms too.
+
+For this example the card reader uTrust 3700 F by the company Identiv was used:
+
+    reader_name = 'Identiv uTrust 3700 F'
+    ...
+    reader = blocksec2go.find_reader(reader_name)
+
+This function returns us the reader as an object to be used with other commands from the blocksec2go library.
+
+The command `select_app(reader)` has to be used in every application that tries to communicate with the BlockSec2Go card because it activates all the Blockchain commands on the card. It also simultaneously returns us some basic information about the card in form of a tuple:
+
+    pin_active, card_id, version = blocksec2go.select_app(reader)
+
+The bool `pin_active` that tells us if the card is locked with a PIN code.  
+The variable `card_id` is a unique card identifier which corresponds to that specific BlockSec2Go card.  
+The string `version` shows the card firmware version.
+
+Before you run the example script on your machine make sure to replace the string from `reader_name` with the name of your card reader. Also make sure that everything is connected and the BlockSec2Go card is placed properly on the reader.
+
+Your Output should look something like:
+
+    Found the specified reader and a card!
+    Is PIN enabled? True
+    Card ID (hex): 02090c2900020027000c
+    Version: v1.0

--- a/examples/get-card-info/README.md
+++ b/examples/get-card-info/README.md
@@ -1,6 +1,6 @@
 # Getting basic card information example
 
-This example shows you how with just a few lines of code you can get the basic card information of your BlockSecurity2Go card.
+This example shows you how with just a few lines of code you can get the basic card information of your Blockchain Security 2Go card.
 
 First the main blocksec2go library will be imported, since it provides us with an easy way to talk with the card reader and more importantly with the card itself:
 
@@ -18,17 +18,17 @@ For this example the card reader uTrust 3700 F by the company Identiv was used:
 
 This function returns us the reader as an object to be used with other commands from the blocksec2go library.
 
-The command `select_app(reader)` has to be used in every application that tries to communicate with the BlockSec2Go card because it activates all the Blockchain commands on the card. It also simultaneously returns us some basic information about the card in form of a tuple:
+The command `select_app(reader)` has to be used in every application that tries to communicate with the Blockchain Security 2Go card because it activates all the Blockchain commands on the card. It also simultaneously returns us some basic information about the card in form of a tuple:
 
     pin_active, card_id, version = blocksec2go.select_app(reader)
 
 The bool `pin_active` that tells us if the card is locked with a PIN code.  
-The variable `card_id` is a unique card identifier which corresponds to that specific BlockSec2Go card.  
+The variable `card_id` is a unique card identifier which corresponds to that specific Blockchain Security 2Go card.  
 The string `version` shows the card firmware version.
 
-Before you run the example script on your machine make sure to replace the string from `reader_name` with the name of your card reader. Also make sure that everything is connected and the BlockSec2Go card is placed properly on the reader.
+Before you run the example script on your machine make sure to replace the string from `reader_name` with the name of your card reader. Also make sure that everything is connected and the Blockchain Security 2Go card is placed properly on the reader.
 
-Your Output should look something like:
+Your output should look something like:
 
     Found the specified reader and a card!
     Is PIN enabled? True

--- a/examples/get-card-info/get_card_info_example.py
+++ b/examples/get-card-info/get_card_info_example.py
@@ -1,0 +1,25 @@
+import blocksec2go
+
+if('__main__' == __name__):
+  reader = None
+  reader_name = 'Identiv uTrust 3700 F'
+  while(reader == None):
+    try:
+      reader = blocksec2go.find_reader(reader_name)
+      print('Found the specified reader and a card!')
+    except Exception as details:
+      if('No reader found' == str(details)):
+        print('No card reader found!     ', end='\r')
+      elif('No card on reader' == str(details)):
+        print('Found reader, but no card!', end='\r')
+      else:
+        print('ERROR:', details)
+        raise SystemExit
+  try:
+    pin_active, card_id, version = blocksec2go.select_app(reader)
+  except Exception as details:
+    print('ERROR:', details)
+    raise SystemExit
+  print('Is PIN enabled?', pin_active)
+  print('Card ID (hex):', card_id.hex())
+  print('Version: ' + version)

--- a/examples/get-card-info/get_card_info_example.py
+++ b/examples/get-card-info/get_card_info_example.py
@@ -6,7 +6,7 @@ if('__main__' == __name__):
   while(reader == None):
     try:
       reader = blocksec2go.find_reader(reader_name)
-      print('Found the specified reader and a card!')
+      print('Found the specified reader and a card!', end='\r')
     except Exception as details:
       if('No reader found' == str(details)):
         print('No card reader found!     ', end='\r')
@@ -17,6 +17,7 @@ if('__main__' == __name__):
         raise SystemExit
   try:
     pin_active, card_id, version = blocksec2go.select_app(reader)
+    print('Found the specified reader and a BlockSec2Go card!')
   except Exception as details:
     print('ERROR:', details)
     raise SystemExit


### PR DESCRIPTION
This example includes a simple python script showing the usage of the functions `find_reader` and `select_app`. It also includes a documentation explaining how the program uses these functions to get some basic card information and how a person might use this example themselves.

Now all the naming scheme problems should be gone.