### PR TITLE
Add feature to verify signature

### DIFF
--- a/blocksec2go/commands.py
+++ b/blocksec2go/commands.py
@@ -4,6 +4,10 @@ logger = logging.getLogger(__name__)
 from smartcard.System import readers
 from blocksec2go.comm.pyscard import open_pyscard
 
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric import utils
+from cryptography.hazmat.primitives import hashes
+
 def find_reader(reader_name):
     """ Looks for a specific card reader
 
@@ -194,6 +198,15 @@ def generate_signature(reader, key_id, hash):
     signature = r.resp[8:]
     logger.debug('global count %d, count %d, signature %s', global_counter, counter, signature.hex())
     return (global_counter, counter, signature)
+
+def verify_signature(key, hash, signature):
+    """ Verification command to check signature
+
+    """
+    logger.debug('VERIFY SIGNATURE public key %s, hash %s, signature %s', key.hex(), hash.hex(), signature.hex())
+
+    public_key = ec.EllipticCurvePublicKey.from_encoded_point(ec.SECP256K1(), key)
+    return public_key.verify(signature, hash, ec.ECDSA(utils.Prehashed(hashes.SHA256()))) == None
 
 def encrypted_keyimport(reader, seed):
     """ Sends command to derive key from given seed

--- a/blocksec2go/commands.py
+++ b/blocksec2go/commands.py
@@ -202,6 +202,22 @@ def generate_signature(reader, key_id, hash):
 def verify_signature(key, hash, signature):
     """ Verification command to check signature
 
+    Verifies a signature which is returned by ``generate_signature``
+    using a public key and the hashed message. The returned value
+    is a True boolean if the signature is verified correctly, but
+    returns a InvalidSignature exception if incorrect.
+
+    Args:
+        key (bytes): `SEC1`_ encoded uncompressed public key
+        hash (bytes): 32 byte long hash which was signed
+        signature (bytes): DER encoded signature
+    
+    Returns:   
+        verification:
+            boolean: True if signature gets verified correctly
+    
+    Raises:
+        Any exceptions thrown by the cryptography wrapper are passed through.
     """
     logger.debug('VERIFY SIGNATURE public key %s, hash %s, signature %s', key.hex(), hash.hex(), signature.hex())
 

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
   packages=find_packages(),
   install_requires=[
     'pyscard'
+    'cryptography'
   ],
   entry_points={
     'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
   license='MIT',
   packages=find_packages(),
   install_requires=[
-    'pyscard'
+    'pyscard',
     'cryptography'
   ],
   entry_points={


### PR DESCRIPTION
`verify_signature(key, hash, signature)`
This new command verifies the signature which is returned by `gernerate_signature` command. For this it uses the public key as it is returned by `get_key_info` and the hashed message in bytes.

If the verification was sucessful then the function returns a boolean which is True. If not, a `InvalidSignature` exception gets passed by the cryptography wrapper.