### PR TITLE
Add example to show usage of functions generate_signature and verify_signature

### DIFF
--- a/blocksec2go/commands.py
+++ b/blocksec2go/commands.py
@@ -146,6 +146,30 @@ def get_key_info(reader, key_id):
     logger.debug('global count %d, count %d, public key %s', global_counter, counter, key.hex())
     return (global_counter, counter, key)
 
+def is_key_valid(reader, key_id):
+    """ Validate retrieved keypair information
+
+    Args:
+        reader (:obj:): object providing reader communication
+        key_id (int): key ID as returned by ``generate_keypair``
+    
+    Returns:
+        key_valid:
+            bool: True if key is valid, else false
+    
+    Raises:
+        RuntimeError: Entered key_id is outside of keypair scope.
+        
+        Any exceptions thrown by the reader wrapper are passed through.
+    """
+    logger.debug('IS KEY VALID key %d', key_id)
+    if key_id < 0 or key_id > 255:
+        raise RuntimeError('Invalid key_id: ' + str(key_id))
+    global_counter, counter, key = get_key_info(reader, key_id)
+    if(0 == global_counter): return False
+    elif(0 == counter): return False
+    else: return True
+
 def generate_signature(reader, key_id, hash):
     """ Send command to calculate signature
 

--- a/examples/generate-and-verify-signature/README.md
+++ b/examples/generate-and-verify-signature/README.md
@@ -1,17 +1,17 @@
-# Generating and verify a signature
+# Generate and verify a signature
 
-This examples shows you how to generate a signature on the Blockchain Security 2Go card and how to verify a signature using the blocksec2go library.
+This examples shows you to generate a signature on the Blockchain Security 2Go card and how to verify a signature using the blocksec2go library.
 
-The contents of `get_reader()` and `activate_card(reader)` have already been covered in the previous example [get-card-info](../get-card-info). The content of `get_public_key(key_id)` has already been covered in the previous example [get_key_info](../get-key-info). Please reference those examples if something is unclear in these functions.
+The contents of `get_reader()` and `activate_card(reader)` have already been covered in the example [get-card-info](../get-card-info) and the content of `get_public_key(key_id)` in the example [get_key_info](../get-key-info). Please reference those earlier examples if something is unclear in these functions.
 
-To use the `generate_signature(reader, key_id, hash)` cpmmand we first need a hashed message that should be signed using the card. In the example we used "Hello World!" as our message and hashed it using the SHA256 algorithm:
+To use the `generate_signature(reader, key_id, hash)` command we first need a hashed message that should be signed using the card. In the example we used "Hello World!" as our message and hashed it using the SHA256 algorithm:
 
     hash_object = hashlib.sha256(b'Hello World!')
     hash = hash_object.digest()
 
 It is important that we leave the hashed message in bytes since this is the format the card accepts.
 
-Next we need a keypair which will be used to sign the hashed message. Please only choose existing keypairs since otherwise there is no private key for the signing process.
+Next, we need a keypair which will be used to sign the hashed message. Please only choose existing keypairs since otherwise there is no private key for the signing process.
 
 After a hashed message and a valid keypair exists we can proceed to actually generating a signature:
 

--- a/examples/generate-and-verify-signature/README.md
+++ b/examples/generate-and-verify-signature/README.md
@@ -11,13 +11,13 @@ To use the `generate_signature(reader, key_id, hash)` command we first need a ha
 
 It is important that we leave the hashed message in bytes since this is the format the card accepts.
 
-Next, we need a keypair which will be used to sign the hashed message. Please only choose existing keypairs since otherwise there is no private key for the signing process.
+Next, we need a keypair which will be used to sign the hashed message. Please be sure to validate the keypair using the function `is_key_valid(reader, key_id)` since otherwise there is no private key for the signing process.
 
-After a hashed message and a valid keypair exists we can proceed to actually generating a signature:
+After a hashed message and a valid keypair exist we can proceed to actually generate a signature:
 
     global_counter, counter, signature = blocksec2go.generate_signature(reader, key_id, hash)
 
-The returned values `global_counter` and `counter` are the same as with the command `get_key_info(reader, key_id)`. The `signature` varibale is the signed hash message in the DER encoded format. For more information on this please check the [Blockchain Security 2Go cards user manual](https://github.com/Infineon/Blockchain/blob/master/doc/BlockchainSecurity2Go_UserManual.pdf) under paragraph *4.3.2.4 GENERATE SIGNATURE* &rightarrow; *Table 24 ASN.1 DER Signature Encoding Details*.
+The returned values `global_counter` and `counter` are the same as with the command `get_key_info(reader, key_id)`. The `signature` varibale is the signed hash message in the DER encoded format. For more information on this please check the [Blockchain Security 2Go user manual](https://github.com/Infineon/Blockchain/blob/master/doc/BlockchainSecurity2Go_UserManual.pdf) under paragraph *4.3.2.4 GENERATE SIGNATURE* &rightarrow; *Table 24 ASN.1 DER Signature Encoding Details*.
 
 The verification of signatures is also possible using the blocksec2go library by using the function `verify_signature(public_key, hash, signature)`. To verify, you will need the hashed message and the public key which correspond to the signed message:
 

--- a/examples/generate-and-verify-signature/README.md
+++ b/examples/generate-and-verify-signature/README.md
@@ -1,0 +1,31 @@
+# Generating and verify a signature
+
+This examples shows you how to generate a signature on the Blockchain Security 2Go card and how to verify a signature using the blocksec2go library.
+
+The contents of `get_reader()` and `activate_card(reader)` have already been covered in the previous example [get-card-info](../get-card-info). The content of `get_public_key(key_id)` has already been covered in the previous example [get_key_info](../get-key-info). Please reference those examples if something is unclear in these functions.
+
+To use the `generate_signature(reader, key_id, hash)` cpmmand we first need a hashed message that should be signed using the card. In the example we used "Hello World!" as our message and hashed it using the SHA256 algorithm:
+
+    hash_object = hashlib.sha256(b'Hello World!')
+    hash = hash_object.digest()
+
+It is important that we leave the hashed message in bytes since this is the format the card accepts.
+
+Next we need a keypair which will be used to sign the hashed message. Please only choose existing keypairs since otherwise there is no private key for the signing process.
+
+After a hashed message and a valid keypair exists we can proceed to actually generating a signature:
+
+    global_counter, counter, signature = blocksec2go.generate_signature(reader, key_id, hash)
+
+The returned values `global_counter` and `counter` are the same as with the command `get_key_info(reader, key_id)`. The `signature` varibale is the signed hash message in the DER encoded format. For more information on this please check the [Blockchain Security 2Go cards user manual](https://github.com/Infineon/Blockchain/blob/master/doc/BlockchainSecurity2Go_UserManual.pdf) under paragraph *4.3.2.4 GENERATE SIGNATURE* &rightarrow; *Table 24 ASN.1 DER Signature Encoding Details*.
+
+The verification of signatures is also possible using the blocksec2go library by using the function `verify_signature(public_key, hash, signature)`. To verify, you will need the hashed message and the public key which correspond to the signed message:
+
+    print('Is signature correct?', blocksec2go.verify_signature(public_key, hash, signature))
+
+This command returns a `True` boolean if the signature is correct. If the signature does not correspond to the given public key and hash then a `InvalidSignature` exception will be called. It is important to note that this exception is not part of the blocksec2go library itself, but is passed on by the cryptography library:
+
+    import cryptography.exceptions as crypto_except
+    ...
+    except crypto_except.InvalidSignature:
+        print('Verification failed!')

--- a/examples/generate-and-verify-signature/README.md
+++ b/examples/generate-and-verify-signature/README.md
@@ -11,7 +11,7 @@ To use the `generate_signature(reader, key_id, hash)` command we first need a ha
 
 It is important that we leave the hashed message in bytes since this is the format the card accepts.
 
-Next, we need a keypair which will be used to sign the hashed message. Please be sure to validate the keypair using the function `is_key_valid(reader, key_id)` since otherwise there is no private key for the signing process.
+Next, we need a keypair which will be used to sign the hashed message. Please be sure to validate the keypair using the function `is_key_valid(reader, key_id)` since otherwise there is a chance that there is no private key for the signing process.
 
 After a hashed message and a valid keypair exist we can proceed to actually generate a signature:
 

--- a/examples/generate-and-verify-signature/generate_and_verify_signature_example.py
+++ b/examples/generate-and-verify-signature/generate_and_verify_signature_example.py
@@ -1,0 +1,62 @@
+import blocksec2go
+import hashlib
+import cryptography.exceptions as crypto_except
+
+def get_reader():
+  reader = None
+  reader_name = 'Identiv uTrust 3700 F'
+  while(reader == None):
+    try:
+      reader = blocksec2go.find_reader(reader_name)
+      print('Found the specified reader and a card!', end='\r')
+    except Exception as details:
+      if('No reader found' == str(details)):
+        print('No card reader found!     ', end='\r')
+      elif('No card on reader' == str(details)):
+        print('Found reader, but no card!', end='\r')
+      else:
+        print('ERROR: ' + str(details))
+        raise SystemExit
+  return reader
+
+def activate_card(reader):
+  try:
+    blocksec2go.select_app(reader)
+    print('Found the specified reader and a Blockchain Security 2Go card!')
+  except Exception as details:
+    print('ERROR: ' + str(details))
+    raise SystemExit
+
+def get_public_key(key_id):
+  try:
+    global_counter, counter, key = blocksec2go.get_key_info(reader, key_id)
+    print('Public key (hex, encoded according to SEC1): ' + key.hex())
+    return key
+  except Exception as details:
+    print('ERROR: ' + str(details))
+    raise SystemExit
+
+if('__main__' == __name__):
+  reader = get_reader()
+  activate_card(reader)
+
+  hash_object = hashlib.sha256(b'Hello World!')
+  hash = hash_object.digest()
+  print('Hashed message:', hash.hex())
+
+  key_id = int(input('Which key would you like to use? (Numbers 1 - 255 only!)\n'))
+  public_key = get_public_key(key_id)
+
+  try:
+    global_counter, counter, signature = blocksec2go.generate_signature(reader, key_id, hash)
+    print('Remaining signatures with card: ', global_counter)
+    print('Remaining signatures with key 1: ', counter)
+    print('Signature (hex): ' + signature.hex())
+
+    print('Is signature correct?', blocksec2go.verify_signature(public_key, hash, signature))
+
+  except crypto_except.InvalidSignature:
+    print('Verification failed!')
+  except Exception as details: 
+    print('ERROR: ' + str(details))
+    raise SystemExit

--- a/examples/generate-and-verify-signature/generate_and_verify_signature_example.py
+++ b/examples/generate-and-verify-signature/generate_and_verify_signature_example.py
@@ -27,11 +27,14 @@ def activate_card(reader):
     print('ERROR: ' + str(details))
     raise SystemExit
 
-def get_public_key(key_id):
+def get_public_key(reader, key_id):
   try:
-    global_counter, counter, key = blocksec2go.get_key_info(reader, key_id)
-    print('Public key (hex, encoded according to SEC1): ' + key.hex())
-    return key
+    if(blocksec2go.is_key_valid(reader, key_id)):
+      global_counter, counter, key = blocksec2go.get_key_info(reader, key_id)
+      print('Public key (hex, encoded according to SEC1): ' + key.hex())
+      return key
+    else:
+      raise RuntimeError('Key_id is invalid!')
   except Exception as details:
     print('ERROR: ' + str(details))
     raise SystemExit
@@ -45,7 +48,7 @@ if('__main__' == __name__):
   print('Hashed message:', hash.hex())
 
   key_id = int(input('Which key would you like to use? (Numbers 1 - 255 only!)\n'))
-  public_key = get_public_key(key_id)
+  public_key = get_public_key(reader, key_id)
 
   try:
     global_counter, counter, signature = blocksec2go.generate_signature(reader, key_id, hash)


### PR DESCRIPTION
This example includes a python script showing the usage of the functions generate_signature and verify_signature. It doesnt yet include the documentation because it will be commited / published next week.