### PR TITLE
Add add_callback and observer class example

### DIFF
--- a/blocksec2go/comm/__init__.py
+++ b/blocksec2go/comm/__init__.py
@@ -1,2 +1,3 @@
 from blocksec2go.comm.pyscard import open_pyscard
 from blocksec2go.comm.base import CardError
+from blocksec2go.comm.card_observer import observer

--- a/blocksec2go/comm/card_observer.py
+++ b/blocksec2go/comm/card_observer.py
@@ -1,0 +1,35 @@
+from smartcard.CardMonitoring import CardMonitor, CardObserver
+
+class card_observer(CardObserver):
+  """ Monitors smartcard
+
+  Monitors insertion or removal of smartcard. Calls functions in 
+  case of insertion/removal.
+  """
+  def connect(self):
+    pass
+
+  def disconnect(self):
+    pass
+
+  def update(self, observable, actions):
+    (addedcards, removedcards) = actions
+    for card in addedcards:
+      self.connect()
+    for card in removedcards:
+      self.disconnect()
+
+class observer:
+  """ Wrapper for card observer
+  
+  Abstracts communication into simple functions so that the user
+  doesn't have to communicate with ``CardMonitoring`` library
+  """
+  def start():
+    cardmonitor = CardMonitor()
+    cardobserver = card_observer()
+    cardmonitor.addObserver(cardobserver)
+    return (cardmonitor, cardobserver)
+
+  def stop(cardmonitor, cardobserver):
+    cardmonitor.deleteObserver(cardobserver)

--- a/blocksec2go/commands.py
+++ b/blocksec2go/commands.py
@@ -2,11 +2,27 @@ import logging
 logger = logging.getLogger(__name__)
 
 from smartcard.System import readers
+from blocksec2go.comm.card_observer import card_observer
 from blocksec2go.comm.pyscard import open_pyscard
 
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric import utils
 from cryptography.hazmat.primitives import hashes
+
+def add_callback(connect, disconnect):
+    """ Add callbacks
+
+    Adds function callbacks to ``CardObserver`` class
+
+    Args:
+        connect (func): Function to call when card gets connected
+        disconnect (func): Function to call when card gets disconnected
+
+    Returns:
+    Raises:
+    """
+    card_observer.connect = connect
+    card_observer.disconnect = disconnect
 
 def find_reader(reader_name):
     """ Looks for a specific card reader

--- a/examples/add-callback/README.md
+++ b/examples/add-callback/README.md
@@ -32,4 +32,10 @@ Apart from the problem mentioned above you would also still need the `reader` ob
         reader = get_reader()
         activate_card(reader)
 
-You can press the "Enter" button at any time on your Keyboard to stop the monitoring process and close the program.
+You can press the "Enter" button on your keyboard at any time to stop the monitoring process and close the program. An example output would look like this:
+
+    Insert a Blockchain Security 2Go card onto the reader!
+    Press Enter at any time to exit the program!
+    A smartcard is connected to the reader!
+    Found the specified reader and a Blockchain Security 2Go card!
+    The card disconnected from the reader!

--- a/examples/add-callback/README.md
+++ b/examples/add-callback/README.md
@@ -12,9 +12,9 @@ It is very important to store the `cardmonitor` and `cardobserver` object since 
 
     observer.stop(cardmonitor, cardobserver)
 
-Please dont forget to stop the monitoring since this can lead to issues with the reader if left open.
+Please do not forget to stop the monitoring since this can lead to issues with the reader if left open.
 
-Using the `add_callback(connect = connected, disconnect = disconnected)` function we are able to add the function `connected(self)` as a callback when a smarcard gets inserted and add the function `disconnected(self)` as a callback when a card gets removed:
+Using the `add_callback(connect = connected, disconnect = disconnected)` function we are able to add the function `connected(self)` as a callback when a smartcard gets inserted and add the function `disconnected(self)` as a callback when a card gets removed:
 
     def connected(self):
     ...
@@ -23,9 +23,9 @@ Using the `add_callback(connect = connected, disconnect = disconnected)` functio
     blocksec2go.add_callback(connect = connected, disconnect = disconnected)
 
 
-Be careful of the fact that at the time when a callback gets triggered there is no guarantee that there is a Blockchain Security 2Go card present or that a Blockchain Security 2Go card was removed. You need to manually check which card reader was affected by the callback or if the card that was inserted was actually a Blockchain Security 2Go card. This is because the callbacks happen whenever any smartcard gets inserted/removed!
+Be careful of the fact that the insertion and removal of any smartcard on any reader also triggers the callbacks above. You need to manually check if the inserted or removed card was a Blockchain Security 2Go card.
 
-Apart from the problem mentioned above you would also still need the `reader` object which is used by the other commands in the  blocksec2go library:
+Additionally you also need the `reader` object which is used by the other commands in the  blocksec2go library:
 
     def connected(self):
         print('A smartcard is connected to the reader!')
@@ -38,4 +38,4 @@ You can press the "Enter" button on your keyboard at any time to stop the monito
     Press Enter at any time to exit the program!
     A smartcard is connected to the reader!
     Found the specified reader and a Blockchain Security 2Go card!
-    The card disconnected from the reader!
+    The card is disconnected from the reader!

--- a/examples/add-callback/README.md
+++ b/examples/add-callback/README.md
@@ -1,0 +1,35 @@
+# Executing functions when card get connected/disconnected
+
+This example shows you how to add callbacks to the insertion/removal of a smartcard. 
+
+The contents of `get_reader()` and `activate_card(reader)` have already been covered in the previous example [get-card-info](../get-card-info). Please reference that example if something is unclear in these functions.
+
+Before we add any callbacks we need to first start monitoring the readers for any smartcard insertions / removals. This is done by using the command `observer.start()`:
+
+    cardmonitor, cardobserver = observer.start()
+
+It is very important to store the `cardmonitor` and `cardobserver` object since these are essential to close the monitoring of the readers:
+
+    observer.stop(cardmonitor, cardobserver)
+
+Please dont forget to stop the monitoring since this can lead to issues with the reader if left open.
+
+Using the `add_callback(connect = connected, disconnect = disconnected)` function we are able to add the function `connected(self)` as a callback when a smarcard gets inserted and add the function `disconnected(self)` as a callback when a card gets removed:
+
+    def connected(self):
+    ...
+    def disconnected(self):
+    ...
+    blocksec2go.add_callback(connect = connected, disconnect = disconnected)
+
+
+Be careful of the fact that at the time when a callback gets triggered there is no guarantee that there is a Blockchain Security 2Go card present or that a Blockchain Security 2Go card was removed. You need to manually check which card reader was affected by the callback or if the card that was inserted was actually a Blockchain Security 2Go card. This is because the callbacks happen whenever any smartcard gets inserted/removed!
+
+Apart from the problem mentioned above you would also still need the `reader` object which is used by the other commands in the  blocksec2go library:
+
+    def connected(self):
+        print('A smartcard is connected to the reader!')
+        reader = get_reader()
+        activate_card(reader)
+
+You can press the "Enter" button at any time on your Keyboard to stop the monitoring process and close the program.

--- a/examples/add-callback/add_callback_example.py
+++ b/examples/add-callback/add_callback_example.py
@@ -1,0 +1,46 @@
+import sys
+from time import sleep
+import blocksec2go
+from blocksec2go.comm import observer
+
+def get_reader():
+  reader = None
+  reader_name = 'Identiv uTrust 3700 F'
+  while(reader == None):
+    try:
+      reader = blocksec2go.find_reader(reader_name)
+      print('Found the specified reader and a card!', end='\r')
+    except Exception as details:
+      if('No reader found' == str(details)):
+        print('No card reader found!     ', end='\r')
+      elif('No card on reader' == str(details)):
+        print('Found reader, but no card!', end='\r')
+      else:
+        print('ERROR: ' + str(details))
+        raise SystemExit
+  return reader
+
+def activate_card(reader):
+  try:
+    blocksec2go.select_app(reader)
+    print('Found the specified reader and a Blockchain Security 2Go card!')
+  except Exception as details:
+    print('ERROR: ' + str(details))
+    raise SystemExit
+
+def connected(self):
+  print('A smartcard is connected to the reader!')
+  reader = get_reader()
+  activate_card(reader)
+
+def disconnected(self):
+  print('The card disconnected from the reader!')
+
+if('__main__' == __name__):
+  print("Insert a Blockchain Security 2Go card onto the reader!")
+  cardmonitor, cardobserver = observer.start()
+  sleep(1)
+  blocksec2go.add_callback(connect = connected, disconnect = disconnected)
+  print('Press Enter at any time to exit the program!')
+  sys.stdin.read(1)
+  observer.stop(cardmonitor, cardobserver)

--- a/examples/add-callback/add_callback_example.py
+++ b/examples/add-callback/add_callback_example.py
@@ -34,7 +34,7 @@ def connected(self):
   activate_card(reader)
 
 def disconnected(self):
-  print('The card disconnected from the reader!')
+  print('The card is disconnected from the reader!')
 
 if('__main__' == __name__):
   print("Insert a Blockchain Security 2Go card onto the reader!")


### PR DESCRIPTION
This very simple example shows the usage of the newly added feature `add_callback` and how to start and stop the reader monitoring for card insertions/removals. It also includes a documentation explaining some of the caveats of this example implementation.